### PR TITLE
Fix sRGB chunk crashing the lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ echo $png_metadata->get('exif:DateTime'); // Return a value, a array or false.
 
 ### Example 3 - Types
 
-Print the metadata types (IHDR, SRBG, BKGD, EXIF, XMP, CRS, DATE, DC, ICC, AUX, ...).
+Print the metadata types (IHDR, sRGB, BKGD, EXIF, XMP, CRS, DATE, DC, ICC, AUX, ...).
 
 ```php
 $png_metadata = new PNGMetadata('./Path/Photo.png');

--- a/src/PNGMetadata.php
+++ b/src/PNGMetadata.php
@@ -448,7 +448,7 @@ class PNGMetadata extends ArrayObject
 		if (isset($this->chunks['sRGB'])) {
 			$rbg = ['Perceptual', 'Relative Colorimetric', 'Saturation', 'Absolute Colorimetric'];
 			$unpacked = unpack('C', $this->chunks['sRGB']);
-			$this->metadata['sRBG'] = $rbg[end(...$unpacked)];
+			$this->metadata['sRBG'] = $rbg[end($unpacked)] ?? 'Unknown';
 		}
 	}
 

--- a/src/PNGMetadata.php
+++ b/src/PNGMetadata.php
@@ -26,7 +26,7 @@ use ArrayObject;
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  *
- * PNG Metadata class for extraction of XMP, TEXIF, EXIF, BKGD, RBG and IHDR.
+ * PNG Metadata class for extraction of XMP, TEXIF, EXIF, BKGD, sRGB and IHDR.
  *
  * Returns the complete information found in the different types
  * of metadata within a PNG format image.
@@ -91,7 +91,7 @@ class PNGMetadata extends ArrayObject
 		$this->extractTExif();
 		$this->extractExif();
 		$this->extractBKGD();
-		$this->extractRBG();
+		$this->extractRGB();
 		$this->extractIHDR();
 		ksort($this->metadata);
 
@@ -438,17 +438,17 @@ class PNGMetadata extends ArrayObject
 
 
 	/**
-	 * Extract RBG type from sRBG chunk as a array.
+	 * Extract RGB type from sRGB chunk as a array.
 	 *
 	 * @see PNGMetadata::$metadata For the property whose metadata are storage.
 	 * @see PNGMetadata::$chunks For the property whose chunks data are storage.
 	 */
-	private function extractRBG(): void
+	private function extractRGB(): void
 	{
 		if (isset($this->chunks['sRGB'])) {
-			$rbg = ['Perceptual', 'Relative Colorimetric', 'Saturation', 'Absolute Colorimetric'];
+			$rgb = ['Perceptual', 'Relative Colorimetric', 'Saturation', 'Absolute Colorimetric'];
 			$unpacked = unpack('C', $this->chunks['sRGB']);
-			$this->metadata['sRBG'] = $rbg[end($unpacked)] ?? 'Unknown';
+			$this->metadata['sRGB'] = $rgb[end($unpacked)] ?? 'Unknown';
 		}
 	}
 


### PR DESCRIPTION
- bug fix / new feature?  bugfix
- BC break? yes

Right now, the whole library crashes on sRGB chunk readout with `Uncaught TypeError: end(): Argument #1 ($array) must be of type array, int given`. This breaking change was introduced in a109b6.
https://github.com/joserick/PNGMetadata/blame/a109b6edc6896a62607657328c34fa936cd18004/src/PNGMetadata.php#L451

[`unpack`](https://www.php.net/manual/en/function.unpack.php) returns an associative array of unpacked elements. The purpose of the `end` function, which only accepts one argument, an array, is in this case to return the last element of this array. Unpacking the array causes an integer (the rendering intent byte) to be passed into it.

It would also be a good idea to replace all mentions of "RBG"  (uncaught typo?) with proper terminology, as specified in [the PNG standard](https://www.w3.org/TR/2003/REC-PNG-20031110/#11sRGB).
