### PR TITLE
Use a memory stream instead of a data stream

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0 <8.1",
-		"ext-exif": "*"
+		"ext-exif": "*",
+		"ext-gd": "*"
 	},
 	"require-dev": {
 		"phpstan/phpstan": "^0.12.74",


### PR DESCRIPTION
- bug fix
- BC break? no

In my environment, using `fopen()` on `data://` streams is prohibited. This accomplishes the same thing, but with a little more work around managing the handle.

Note: the handle is left unclosed at this point. I will look into closing it if this approach is accepted.
